### PR TITLE
Move namespace config into kustomization files

### DIFF
--- a/argo-cd/applications/dev/applications.yaml
+++ b/argo-cd/applications/dev/applications.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: applications
-  namespace: argocd
 spec:
   destination:
     namespace: argocd

--- a/argo-cd/applications/dev/doc-index-updater.yaml
+++ b/argo-cd/applications/dev/doc-index-updater.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: doc-index-updater
-  namespace: argocd
 spec:
   destination:
     namespace: doc-index-updater

--- a/argo-cd/applications/dev/kustomization.yaml
+++ b/argo-cd/applications/dev/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: argocd
+
 resources:
   - applications.yaml
   - doc-index-updater.yaml

--- a/argo-cd/applications/local/applications.yaml
+++ b/argo-cd/applications/local/applications.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: applications
-  namespace: argocd
 spec:
   destination:
     namespace: argocd

--- a/argo-cd/applications/local/doc-index-updater.yaml
+++ b/argo-cd/applications/local/doc-index-updater.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: doc-index-updater
-  namespace: argocd
 spec:
   destination:
     namespace: doc-index-updater

--- a/argo-cd/applications/local/egress.yaml
+++ b/argo-cd/applications/local/egress.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: egress
-  namespace: argocd
 spec:
   destination:
     namespace: istio-system

--- a/argo-cd/applications/local/kustomization.yaml
+++ b/argo-cd/applications/local/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: argocd
+
 resources:
   - applications.yaml
   - doc-index-updater.yaml

--- a/argo-cd/applications/non-prod/applications.yaml
+++ b/argo-cd/applications/non-prod/applications.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: applications
-  namespace: argocd
 spec:
   destination:
     namespace: argocd

--- a/argo-cd/applications/non-prod/doc-index-updater.yaml
+++ b/argo-cd/applications/non-prod/doc-index-updater.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: doc-index-updater
-  namespace: argocd
 spec:
   destination:
     namespace: doc-index-updater

--- a/argo-cd/applications/non-prod/kustomization.yaml
+++ b/argo-cd/applications/non-prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: argocd
+
 resources:
   - applications.yaml
   - doc-index-updater.yaml

--- a/argo-cd/applications/prod/applications.yaml
+++ b/argo-cd/applications/prod/applications.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: applications
-  namespace: argocd
 spec:
   destination:
     namespace: argocd

--- a/argo-cd/applications/prod/doc-index-updater.yaml
+++ b/argo-cd/applications/prod/doc-index-updater.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: doc-index-updater
-  namespace: argocd
 spec:
   destination:
     namespace: doc-index-updater

--- a/argo-cd/applications/prod/kustomization.yaml
+++ b/argo-cd/applications/prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: argocd
+
 resources:
   - applications.yaml
   - doc-index-updater.yaml

--- a/doc-index-updater/overlays/dev/kustomization.yaml
+++ b/doc-index-updater/overlays/dev/kustomization.yaml
@@ -1,17 +1,19 @@
+namespace: doc-index-updater
+
 resources:
-- ../../base
-- SealedSecret-basic-auth-creds.yaml
-- SealedSecret-redis-creds.yaml
-- SealedSecret-search-creds.yaml
-- SealedSecret-sentinel-creds.yaml
-- SealedSecret-service-bus-creds.yaml
-- SealedSecret-storage-creds.yaml
+  - ../../base
+  - SealedSecret-basic-auth-creds.yaml
+  - SealedSecret-redis-creds.yaml
+  - SealedSecret-search-creds.yaml
+  - SealedSecret-sentinel-creds.yaml
+  - SealedSecret-service-bus-creds.yaml
+  - SealedSecret-storage-creds.yaml
 patchesStrategicMerge:
-- deployment.yaml
-- ingress.yaml
+  - deployment.yaml
+  - ingress.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:b193d6737896f6d26af0d351adab1782c2f1b9779c2742c656bad5da94178610
-  name: mhraproductsnonprodregistry.azurecr.io/products/doc-index-updater
+  - digest: sha256:b193d6737896f6d26af0d351adab1782c2f1b9779c2742c656bad5da94178610
+    name: mhraproductsnonprodregistry.azurecr.io/products/doc-index-updater

--- a/doc-index-updater/overlays/local/kustomization.yaml
+++ b/doc-index-updater/overlays/local/kustomization.yaml
@@ -1,2 +1,4 @@
+namespace: doc-index-updater
+
 resources:
   - ../../base

--- a/doc-index-updater/overlays/non-prod/kustomization.yaml
+++ b/doc-index-updater/overlays/non-prod/kustomization.yaml
@@ -1,17 +1,19 @@
+namespace: doc-index-updater
+
 resources:
-- ../../base
-- SealedSecret-basic-auth-creds.yaml
-- SealedSecret-redis-creds.yaml
-- SealedSecret-search-creds.yaml
-- SealedSecret-sentinel-creds.yaml
-- SealedSecret-service-bus-creds.yaml
-- SealedSecret-storage-creds.yaml
+  - ../../base
+  - SealedSecret-basic-auth-creds.yaml
+  - SealedSecret-redis-creds.yaml
+  - SealedSecret-search-creds.yaml
+  - SealedSecret-sentinel-creds.yaml
+  - SealedSecret-service-bus-creds.yaml
+  - SealedSecret-storage-creds.yaml
 patchesStrategicMerge:
-- deployment.yaml
-- ingress.yaml
+  - deployment.yaml
+  - ingress.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:d07d1c9e8d3af4693e214c27ed9914695922dd40c4181283c0d2e03706193420
-  name: mhraproductsnonprodregistry.azurecr.io/products/doc-index-updater
+  - digest: sha256:d07d1c9e8d3af4693e214c27ed9914695922dd40c4181283c0d2e03706193420
+    name: mhraproductsnonprodregistry.azurecr.io/products/doc-index-updater

--- a/doc-index-updater/overlays/prod/kustomization.yaml
+++ b/doc-index-updater/overlays/prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: doc-index-updater
+
 resources:
   - ../../base
   - SealedSecret-basic-auth-creds.yaml

--- a/egress/overlays/dev/kustomization.yaml
+++ b/egress/overlays/dev/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: istio-system
+
 resources:
   - ../../base
 

--- a/egress/overlays/local/kustomization.yaml
+++ b/egress/overlays/local/kustomization.yaml
@@ -1,2 +1,4 @@
+namespace: istio-system
+
 resources:
   - ../../base

--- a/egress/overlays/non-prod/kustomization.yaml
+++ b/egress/overlays/non-prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: istio-system
+
 resources:
   - ../../base
   - sentinel-dev.yaml

--- a/egress/overlays/prod/kustomization.yaml
+++ b/egress/overlays/prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: istio-system
+
 resources:
   - ../../base
   - sentinel.yaml

--- a/istio/custom/gateway.yaml
+++ b/istio/custom/gateway.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: ingressgateway
-  namespace: istio-system
 spec:
   servers:
     - port:

--- a/istio/custom/kustomization.yaml
+++ b/istio/custom/kustomization.yaml
@@ -1,2 +1,4 @@
+namespace: istio-system
+
 resources:
   - gateway.yaml

--- a/istio/overlays/dev/kustomization.yaml
+++ b/istio/overlays/dev/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: istio-system
+
 resources:
   - ../../custom
   - container-azm-ms-agentconfig.yaml

--- a/istio/overlays/dev/prometheus-configmap.yaml
+++ b/istio/overlays/dev/prometheus-configmap.yaml
@@ -10,7 +10,6 @@ metadata:
     install.operator.istio.io/owner-name: istiocontrolplane
     release: istio
   name: prometheus
-  namespace: istio-system
 data:
   prometheus.rules.yml: |
     groups:

--- a/istio/overlays/dev/service-ingress-internal.yaml
+++ b/istio/overlays/dev/service-ingress-internal.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-ingressgateway-internal
-  namespace: istio-system
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     service.beta.kubernetes.io/azure-load-balancer-internal-subnet: adarz-spoke-products-dev-sn-01

--- a/istio/overlays/local/kustomization.yaml
+++ b/istio/overlays/local/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: istio-system
+
 resources:
   - ../../custom
   - profile.yaml

--- a/istio/overlays/local/profile.yaml
+++ b/istio/overlays/local/profile.yaml
@@ -1,7 +1,6 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
-  namespace: istio-system
   name: istiocontrolplane
 spec:
   profile: default

--- a/istio/overlays/non-prod/kustomization.yaml
+++ b/istio/overlays/non-prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: istio-system
+
 resources:
   - ../../custom
   - service-ingress-internal.yaml

--- a/istio/overlays/non-prod/service-ingress-internal.yaml
+++ b/istio/overlays/non-prod/service-ingress-internal.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-ingressgateway-internal
-  namespace: istio-system
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     service.beta.kubernetes.io/azure-load-balancer-internal-subnet: adarz-spoke-products-sn-01

--- a/istio/overlays/prod/kustomization.yaml
+++ b/istio/overlays/prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: istio-system
+
 resources:
   - ../../custom
   - service-ingress-internal.yaml

--- a/istio/overlays/prod/service-ingress-internal.yaml
+++ b/istio/overlays/prod/service-ingress-internal.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-ingressgateway-internal
-  namespace: istio-system
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     service.beta.kubernetes.io/azure-load-balancer-internal-subnet: aparz-spoke-products-sn-01

--- a/istio/profile/kustomization.yaml
+++ b/istio/profile/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: istio-system
+
 resources:
   - namespace.yaml
   # - peer-authentication.yaml

--- a/istio/profile/peer-authentication.yaml
+++ b/istio/profile/peer-authentication.yaml
@@ -2,7 +2,6 @@ apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
   name: default
-  namespace: istio-system
 spec:
   mtls:
     mode: PERMISSIVE

--- a/istio/profile/profile.yaml
+++ b/istio/profile/profile.yaml
@@ -1,7 +1,6 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
-  namespace: istio-system
   name: istiocontrolplane
 spec:
   profile: demo

--- a/kube-state-metrics/base/deployment.yaml
+++ b/kube-state-metrics/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: 1.9.5
   name: kube-state-metrics
-  namespace: kube-system
 spec:
   replicas: 1
   selector:

--- a/kube-state-metrics/base/kustomization.yaml
+++ b/kube-state-metrics/base/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: kube-system
+
 resources:
   - cluster-role-binding.yaml
   - cluster-role.yaml

--- a/kube-state-metrics/base/service-account.yaml
+++ b/kube-state-metrics/base/service-account.yaml
@@ -5,4 +5,3 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: 1.9.5
   name: kube-state-metrics
-  namespace: kube-system

--- a/kube-state-metrics/base/service.yaml
+++ b/kube-state-metrics/base/service.yaml
@@ -5,7 +5,6 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: 1.9.5
   name: kube-state-metrics
-  namespace: kube-system
 spec:
   clusterIP: None
   ports:

--- a/sealed-secrets/base/Deployment-sealed-secrets-controller.yaml
+++ b/sealed-secrets/base/Deployment-sealed-secrets-controller.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     name: sealed-secrets-controller
   name: sealed-secrets-controller
-  namespace: kube-system
 spec:
   minReadySeconds: 30
   replicas: 1
@@ -26,33 +25,33 @@ spec:
         name: sealed-secrets-controller
     spec:
       containers:
-      - args: []
-        command:
-        - controller
-        env: []
-        image: quay.io/bitnami/sealed-secrets-controller:v0.9.8
-        imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-        name: sealed-secrets-controller
-        ports:
-        - containerPort: 8080
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1001
-        stdin: false
-        tty: false
-        volumeMounts:
-        - mountPath: /tmp
-          name: tmp
+        - args: []
+          command:
+            - controller
+          env: []
+          image: quay.io/bitnami/sealed-secrets-controller:v0.9.8
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          name: sealed-secrets-controller
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+          stdin: false
+          tty: false
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
       imagePullSecrets: []
       initContainers: []
       securityContext:
@@ -60,5 +59,5 @@ spec:
       serviceAccountName: sealed-secrets-controller
       terminationGracePeriodSeconds: 30
       volumes:
-      - emptyDir: {}
-        name: tmp
+        - emptyDir: {}
+          name: tmp

--- a/sealed-secrets/base/Role-sealed-secrets-key-admin.yaml
+++ b/sealed-secrets/base/Role-sealed-secrets-key-admin.yaml
@@ -7,12 +7,11 @@ metadata:
   labels:
     name: sealed-secrets-key-admin
   name: sealed-secrets-key-admin
-  namespace: kube-system
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - list

--- a/sealed-secrets/base/Role-sealed-secrets-service-proxier.yaml
+++ b/sealed-secrets/base/Role-sealed-secrets-service-proxier.yaml
@@ -6,15 +6,14 @@ metadata:
   labels:
     name: sealed-secrets-service-proxier
   name: sealed-secrets-service-proxier
-  namespace: kube-system
 rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - 'http:sealed-secrets-controller:'
-  - sealed-secrets-controller
-  resources:
-  - services/proxy
-  verbs:
-  - create
-  - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - "http:sealed-secrets-controller:"
+      - sealed-secrets-controller
+    resources:
+      - services/proxy
+    verbs:
+      - create
+      - get

--- a/sealed-secrets/base/RoleBinding-sealed-secrets-controller.yaml
+++ b/sealed-secrets/base/RoleBinding-sealed-secrets-controller.yaml
@@ -6,12 +6,11 @@ metadata:
   labels:
     name: sealed-secrets-controller
   name: sealed-secrets-controller
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: sealed-secrets-key-admin
 subjects:
-- kind: ServiceAccount
-  name: sealed-secrets-controller
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: sealed-secrets-controller
+    namespace: kube-system

--- a/sealed-secrets/base/RoleBinding-sealed-secrets-service-proxier.yaml
+++ b/sealed-secrets/base/RoleBinding-sealed-secrets-service-proxier.yaml
@@ -6,12 +6,11 @@ metadata:
   labels:
     name: sealed-secrets-service-proxier
   name: sealed-secrets-service-proxier
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: sealed-secrets-service-proxier
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:authenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/sealed-secrets/base/Service-sealed-secrets-controller.yaml
+++ b/sealed-secrets/base/Service-sealed-secrets-controller.yaml
@@ -6,11 +6,10 @@ metadata:
   labels:
     name: sealed-secrets-controller
   name: sealed-secrets-controller
-  namespace: kube-system
 spec:
   ports:
-  - port: 8080
-    targetPort: 8080
+    - port: 8080
+      targetPort: 8080
   selector:
     name: sealed-secrets-controller
   type: ClusterIP

--- a/sealed-secrets/base/ServiceAccount-sealed-secrets-controller.yaml
+++ b/sealed-secrets/base/ServiceAccount-sealed-secrets-controller.yaml
@@ -6,4 +6,3 @@ metadata:
   labels:
     name: sealed-secrets-controller
   name: sealed-secrets-controller
-  namespace: kube-system

--- a/sealed-secrets/base/controller.yaml
+++ b/sealed-secrets/base/controller.yaml
@@ -6,15 +6,14 @@ metadata:
   labels:
     name: sealed-secrets-key-admin
   name: sealed-secrets-key-admin
-  namespace: kube-system
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -28,9 +27,9 @@ roleRef:
   kind: ClusterRole
   name: secrets-unsealer
 subjects:
-- kind: ServiceAccount
-  name: sealed-secrets-controller
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: sealed-secrets-controller
+    namespace: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -65,8 +64,8 @@ metadata:
   namespace: kube-system
 spec:
   ports:
-  - port: 8080
-    targetPort: 8080
+    - port: 8080
+      targetPort: 8080
   selector:
     name: sealed-secrets-controller
   type: ClusterIP
@@ -84,9 +83,9 @@ roleRef:
   kind: Role
   name: sealed-secrets-service-proxier
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:authenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -101,9 +100,9 @@ roleRef:
   kind: Role
   name: sealed-secrets-key-admin
 subjects:
-- kind: ServiceAccount
-  name: sealed-secrets-controller
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: sealed-secrets-controller
+    namespace: kube-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -132,33 +131,33 @@ spec:
         name: sealed-secrets-controller
     spec:
       containers:
-      - args: []
-        command:
-        - controller
-        env: []
-        image: quay.io/bitnami/sealed-secrets-controller:v0.9.8
-        imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-        name: sealed-secrets-controller
-        ports:
-        - containerPort: 8080
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1001
-        stdin: false
-        tty: false
-        volumeMounts:
-        - mountPath: /tmp
-          name: tmp
+        - args: []
+          command:
+            - controller
+          env: []
+          image: quay.io/bitnami/sealed-secrets-controller:v0.9.8
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          name: sealed-secrets-controller
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+          stdin: false
+          tty: false
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
       imagePullSecrets: []
       initContainers: []
       securityContext:
@@ -166,8 +165,8 @@ spec:
       serviceAccountName: sealed-secrets-controller
       terminationGracePeriodSeconds: 30
       volumes:
-      - emptyDir: {}
-        name: tmp
+        - emptyDir: {}
+          name: tmp
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
@@ -178,16 +177,16 @@ metadata:
   name: sealed-secrets-service-proxier
   namespace: kube-system
 rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - 'http:sealed-secrets-controller:'
-  - sealed-secrets-controller
-  resources:
-  - services/proxy
-  verbs:
-  - create
-  - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - "http:sealed-secrets-controller:"
+      - sealed-secrets-controller
+    resources:
+      - services/proxy
+    verbs:
+      - create
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -197,28 +196,28 @@ metadata:
     name: secrets-unsealer
   name: secrets-unsealer
 rules:
-- apiGroups:
-  - bitnami.com
-  resources:
-  - sealedsecrets
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/sealed-secrets/base/kustomization.yaml
+++ b/sealed-secrets/base/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: kube-system
+
 resources:
   - ServiceAccount-sealed-secrets-controller.yaml
   - CustomResourceDefinition-sealedsecrets.bitnami.com.yaml

--- a/sealed-secrets/overlays/dev/kustomization.yaml
+++ b/sealed-secrets/overlays/dev/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: kube-system
+
 resources:
   - sealed-secrets-key.yaml
   - ../../base

--- a/sealed-secrets/overlays/local/kustomization.yaml
+++ b/sealed-secrets/overlays/local/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: kube-system
+
 resources:
   - sealed-secrets-key.yaml
   - ../../base

--- a/sealed-secrets/overlays/non-prod/kustomization.yaml
+++ b/sealed-secrets/overlays/non-prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: kube-system
+
 resources:
   - sealed-secrets-key.yaml
   - ../../base

--- a/sealed-secrets/overlays/prod/kustomization.yaml
+++ b/sealed-secrets/overlays/prod/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: kube-system
+
 resources:
   - sealed-secrets-key.yaml
   - ../../base


### PR DESCRIPTION
Namespaces weren't defined in some resource definition yamls, so the resources were being created in `default` namespace.

These changes move the namespace definitions out to the `kustomization` files in order to ensure namespaces are being applied to all referenced resource definitions and will be applied to all resources added in future.