### PR TITLE
Add message timeout to increase from default 10s

### DIFF
--- a/doc-index-updater/overlays/non-prod/deployment.yaml
+++ b/doc-index-updater/overlays/non-prod/deployment.yaml
@@ -16,7 +16,5 @@ spec:
               value: doc-index-updater-non-prod
             - name: SEARCH_SERVICE
               value: mhraproductsnonprod
-            - name: SERVICE_BUS_NAMESPACE
-              value: doc-index-updater-non-prod
             - name: RUST_LOG
               value: doc_index_updater=debug,info

--- a/doc-index-updater/overlays/non-prod/kustomization.yaml
+++ b/doc-index-updater/overlays/non-prod/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 patchesStrategicMerge:
   - deployment.yaml
   - ingress.yaml
+  - lock-timeout.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/doc-index-updater/overlays/non-prod/lock-timeout.yaml
+++ b/doc-index-updater/overlays/non-prod/lock-timeout.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: doc-index-updater
+spec:
+  template:
+    spec:
+      containers:
+        - name: doc-index-updater
+          env:
+            - name: SERVICE_BUS_MESSAGE_LOCK_TIMEOUT
+              value: 60


### PR DESCRIPTION
Currently this env var is unspecified and defaults to 10 seconds.
Seeing in nonprod that it can take a while to authenticate with the sftp server and properly process the message. In that time, the lock is being released and is being picked up again, leading to the work being duplicated.
The message timeout should be increased to prevent this from happening, at least until the long timeout issue is resolved.