### PR TITLE
Prod config changes

### DIFF
--- a/doc-index-updater/overlays/prod/deployment.yaml
+++ b/doc-index-updater/overlays/prod/deployment.yaml
@@ -16,3 +16,5 @@ spec:
               value: mhraproductsproduction
             - name: SERVICE_BUS_NAMESPACE
               value: doc-index-updater-production
+            - name: RUST_LOG
+              value: doc_index_updater=info

--- a/doc-index-updater/overlays/prod/kustomization.yaml
+++ b/doc-index-updater/overlays/prod/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 patchesStrategicMerge:
   - deployment.yaml
   - ingress.yaml
+  - lock-timeout.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/doc-index-updater/overlays/prod/lock-timeout.yaml
+++ b/doc-index-updater/overlays/prod/lock-timeout.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: doc-index-updater
+spec:
+  template:
+    spec:
+      containers:
+        - name: doc-index-updater
+          env:
+            - name: SERVICE_BUS_MESSAGE_LOCK_TIMEOUT
+              value: "10"


### PR DESCRIPTION
Changes to prod config in preparation for going live:
- Min log level changed from `warning` (default) to `info`
- Explicit definition of lock timeout