### PR TITLE
Automatically restart Prometheus in Makefile

### DIFF
--- a/istio/init-1/profile.yaml
+++ b/istio/init-1/profile.yaml
@@ -17,3 +17,4 @@ spec:
         mode: REGISTRY_ONLY
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
+    prometheus:

--- a/istio/init-1/profile.yaml
+++ b/istio/init-1/profile.yaml
@@ -17,4 +17,3 @@ spec:
         mode: REGISTRY_ONLY
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
-    prometheus:

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -1,7 +1,14 @@
 
 .PHONY: default
-default: ## Create resources
+default: apply restart-prometheus ## Create resources
+
+.PHONY: apply
+apply: ## Apply kubernetes manifests
 	kustomize build . | kubectl apply -f -
+
+.PHONY: restart-prometheus
+restart-prometheus: ## Restart prometheus so config changes take effect
+	kubectl delete pods -l app=prometheus -n istio-system
 
 .PHONY: delete
 delete: ## Delete resources


### PR DESCRIPTION
Whenever prometheus's config map changes it needs to be reloaded for it to take effect.

Just deleting the pod works for now, but unfortunately this also deletes the locally stored metrics history. This data is pulled into Azure Monitor anyway so we wouldn't lose it completely, but it's still not ideal.

Prometheus does have a `/-/reload` HTTP endpoint for [reloading the config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) but it's disabled by default and I haven't found if/how to enable it through the istio profile yet.