### PR TITLE
Add JWT Auth to PARS endpoint

### DIFF
--- a/doc-index-updater/base/authentication.yaml
+++ b/doc-index-updater/base/authentication.yaml
@@ -1,0 +1,12 @@
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
+metadata:
+  name: doc-index-updater
+  namespace: doc-index-updater
+spec:
+  selector:
+    matchLabels:
+      app: doc-index-updater
+  jwtRules:
+  - issuer: "https://login.microsoftonline.com/a3ab1acc-ee06-40e0-9038-544c45394737/v2.0"
+    jwksUri: "https://login.microsoftonline.com/a3ab1acc-ee06-40e0-9038-544c45394737/discovery/v2.0/keys"

--- a/doc-index-updater/base/authorization.yaml
+++ b/doc-index-updater/base/authorization.yaml
@@ -9,10 +9,20 @@ spec:
       app: doc-index-updater
   action: ALLOW
   rules:
-    - from:
+    - to:
+        - operation:
+            notPaths:
+              - "/pars"
+              - "/pars/*"
+    - to:
+        - operation:
+            paths:
+              - "/pars"
+              - "/pars/*"
+      from:
         - source:
             requestPrincipals:
               - "*"
-  #     # when:
-  #   - key: request.auth.claims[groups]
-  #     values: ["group1"]
+    #  when:
+    #   - key: request.auth.claims[groups]
+    #     values: ["medical_writers"]

--- a/doc-index-updater/base/authorization.yaml
+++ b/doc-index-updater/base/authorization.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: doc-index-updater
+  namespace: doc-index-updater
+spec:
+  selector:
+    matchLabels:
+      app: doc-index-updater
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            requestPrincipals:
+              - "*"
+  #     # when:
+  #   - key: request.auth.claims[groups]
+  #     values: ["group1"]

--- a/doc-index-updater/base/authorization.yaml
+++ b/doc-index-updater/base/authorization.yaml
@@ -23,6 +23,3 @@ spec:
         - source:
             requestPrincipals:
               - "*"
-    #  when:
-    #   - key: request.auth.claims[groups]
-    #     values: ["medical_writers"]

--- a/doc-index-updater/base/kustomization.yaml
+++ b/doc-index-updater/base/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - authentication.yaml
+  - authorization.yaml

--- a/egress/base/kustomization.yaml
+++ b/egress/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - search-service.yaml
   - service-bus.yaml
   - storage-service.yaml
+  - microsoft-jwks.yaml

--- a/egress/base/microsoft-jwks.yaml
+++ b/egress/base/microsoft-jwks.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: microsoft-jwks
+spec:
+  hosts:
+    - login.microsoftonline.com
+  ports:
+    - number: 443
+      name: https
+      protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: microsoft-jwks
+spec:
+  hosts:
+    - login.microsoftonline.com
+  tls:
+    - match:
+        - port: 443
+          sni_hosts:
+            - login.microsoftonline.com
+      route:
+        - destination:
+            host: login.microsoftonline.com
+            port:
+              number: 443
+          weight: 100


### PR DESCRIPTION
- Adds Authentication via JWT at Istio level for doc-index-updater
- Adds Authorisation for /pars endpoint for all authenticated users
- Bypasses Authentication and Authorisation for all other endpoints.