### PR TITLE
Update deprecated sni_hosts to sniHosts

### DIFF
--- a/egress/base/github.yaml
+++ b/egress/base/github.yaml
@@ -22,7 +22,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - github.com
       route:
         - destination:

--- a/egress/base/logs-storage-service.yaml
+++ b/egress/base/logs-storage-service.yaml
@@ -22,7 +22,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - mhralogsnonprod.blob.core.windows.net
       route:
         - destination:

--- a/egress/base/microsoft-jwks.yaml
+++ b/egress/base/microsoft-jwks.yaml
@@ -22,7 +22,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - login.microsoftonline.com
       route:
         - destination:

--- a/egress/base/search-service.yaml
+++ b/egress/base/search-service.yaml
@@ -22,7 +22,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - mhraproductsnonprod.search.windows.net
       route:
         - destination:

--- a/egress/base/service-bus.yaml
+++ b/egress/base/service-bus.yaml
@@ -22,7 +22,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - doc-index-updater-dev.servicebus.windows.net
       route:
         - destination:

--- a/egress/base/storage-service.yaml
+++ b/egress/base/storage-service.yaml
@@ -22,7 +22,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - mhraproductsnonprod.blob.core.windows.net
       route:
         - destination:

--- a/egress/overlays/dev/search-service.yaml
+++ b/egress/overlays/dev/search-service.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - mhraproductsdevelopment.search.windows.net
       route:
         - destination:

--- a/egress/overlays/non-prod/kustomization.yaml
+++ b/egress/overlays/non-prod/kustomization.yaml
@@ -55,7 +55,7 @@ patchesJSON6902:
         path: /spec/hosts/0
         value: doc-index-updater-non-prod.servicebus.windows.net
       - op: replace
-        path: /spec/tls/0/match/0/sni_hosts/0
+        path: /spec/tls/0/match/0/sniHosts/0
         value: doc-index-updater-non-prod.servicebus.windows.net
       - op: replace
         path: /spec/tls/0/route/0/destination/host

--- a/egress/overlays/prod-new/search-service.yaml
+++ b/egress/overlays/prod-new/search-service.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - mhraproducts4853.search.windows.net
       route:
         - destination:

--- a/egress/overlays/prod-new/service-bus.yaml
+++ b/egress/overlays/prod-new/service-bus.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - doc-index-updater-4853.servicebus.windows.net
       route:
         - destination:

--- a/egress/overlays/prod-new/storage-service.yaml
+++ b/egress/overlays/prod-new/storage-service.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - mhraproducts4853.blob.core.windows.net
       route:
         - destination:

--- a/egress/overlays/prod/logs-storage-service.yaml
+++ b/egress/overlays/prod/logs-storage-service.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - logsmhraproduction.blob.core.windows.net
       route:
         - destination:

--- a/egress/overlays/prod/search-service.yaml
+++ b/egress/overlays/prod/search-service.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - mhraproductsproduction.search.windows.net
       route:
         - destination:

--- a/egress/overlays/prod/service-bus.yaml
+++ b/egress/overlays/prod/service-bus.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - doc-index-updater-production.servicebus.windows.net
       route:
         - destination:

--- a/egress/overlays/prod/storage-service.yaml
+++ b/egress/overlays/prod/storage-service.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - match:
         - port: 443
-          sni_hosts:
+          sniHosts:
             - mhraproductsproduction.blob.core.windows.net
       route:
         - destination:


### PR DESCRIPTION
sni_hosts looks to be deprecated and was causing errors when initialising VirtualServices - replaced with sniHosts, as documented, and seems to work as expected.