### PR TITLE
Add gateways to virtualservices

### DIFF
--- a/doc-index-updater/overlays/non-prod/ingress.yaml
+++ b/doc-index-updater/overlays/non-prod/ingress.yaml
@@ -7,6 +7,9 @@ spec:
   hosts:
     - doc-index-updater.test.mhra.gov.uk
     - doc-index-updater.non-prod.mhra.gov.uk
+  gateways:
+    - istio-system/ingressgateway
+    - istio-system/doc-index-updater-ingressgateway
   http:
     - route:
         - destination:

--- a/doc-index-updater/overlays/prod-new/ingress.yaml
+++ b/doc-index-updater/overlays/prod-new/ingress.yaml
@@ -6,3 +6,6 @@ spec:
   hosts:
     - doc-index-updater.mhra.gov.uk
     - doc-index-updater.api.mhra.gov.uk
+  gateways:
+    - istio-system/ingressgateway
+    - istio-system/doc-index-updater-ingressgateway

--- a/medicines-api/overlays/non-prod/ingress.yaml
+++ b/medicines-api/overlays/non-prod/ingress.yaml
@@ -7,3 +7,6 @@ spec:
   hosts:
     - medicines-api.non-prod.mhra.gov.uk
     - medicines-api.test.mhra.gov.uk
+  gateways:
+    - istio-system/ingressgateway
+    - istio-system/medicines-api-ingressgateway

--- a/medicines-api/overlays/prod-new/ingress.yaml
+++ b/medicines-api/overlays/prod-new/ingress.yaml
@@ -5,3 +5,6 @@ metadata:
 spec:
   hosts:
     - medicines.api.mhra.gov.uk
+  gateways:
+    - istio-system/ingressgateway
+    - istio-system/medicines-api-ingressgateway


### PR DESCRIPTION
Without explicit setting of gateways, each virtual service [defaults to istio-system/ingressgateway only](https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService). This means that the `non-prod` routes specified in the service-specific gateways were 404-ing.