### PR TITLE
Remove http redirects for port 80

### DIFF
--- a/doc-index-updater/overlays/prod/gateway.yaml
+++ b/doc-index-updater/overlays/prod/gateway.yaml
@@ -6,15 +6,6 @@ metadata:
 spec:
   servers:
     - port:
-        number: 80
-        name: http
-        protocol: HTTP
-      hosts:
-        - doc-index-updater.api.mhra.gov.uk
-        - doc-index-updater.mhra.gov.uk
-      tls:
-        httpsRedirect: true # sends 301 redirect for http requests
-    - port:
         number: 443
         name: https-443-api-mhra-gov-uk
         protocol: HTTPS

--- a/medicines-api/overlays/prod/gateway.yaml
+++ b/medicines-api/overlays/prod/gateway.yaml
@@ -6,14 +6,6 @@ metadata:
 spec:
   servers:
     - port:
-        number: 80
-        name: http
-        protocol: HTTP
-      hosts:
-        - medicines.api.mhra.gov.uk
-      tls:
-        httpsRedirect: true # sends 301 redirect for http requests
-    - port:
         number: 443
         name: https-443-medicines-api
         protocol: HTTPS


### PR DESCRIPTION
This redirect rule conflicts with the http rule required for cert-manager HTTP challenge, as the challenge gets redirected to port 443. The redirect rule arguably shouldn't be in place for APIs so removing to avoid this conflict.