### PR TITLE
Add rbac access for argocd to istio-system

### DIFF
--- a/argo-cd/2-base/kustomization.yaml
+++ b/argo-cd/2-base/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: argocd
+
 resources:
   - install.yaml
 

--- a/argo-cd/3-custom/argocd-application-controller.yaml
+++ b/argo-cd/3-custom/argocd-application-controller.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
   name: argocd-application-controller
+  namespace: argocd
 spec:
   template:
     metadata:

--- a/argo-cd/3-custom/argocd-cm.yaml
+++ b/argo-cd/3-custom/argocd-cm.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
+  namespace: argocd
 data:
   repositories: |
     - url: https://github.com/MHRA/deployments.git

--- a/argo-cd/3-custom/argocd-dex-server.yaml
+++ b/argo-cd/3-custom/argocd-dex-server.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
   name: argocd-dex-server
+  namespace: argocd
 spec:
   template:
     metadata:

--- a/argo-cd/3-custom/argocd-redis.yaml
+++ b/argo-cd/3-custom/argocd-redis.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
   name: argocd-redis
+  namespace: argocd
 spec:
   template:
     metadata:

--- a/argo-cd/3-custom/argocd-repo-server.yaml
+++ b/argo-cd/3-custom/argocd-repo-server.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
   name: argocd-repo-server
+  namespace: argocd
 spec:
   template:
     metadata:

--- a/argo-cd/3-custom/argocd-server-deployment.yaml
+++ b/argo-cd/3-custom/argocd-server-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argocd-server
+  namespace: argocd
 spec:
   template:
     metadata:

--- a/argo-cd/3-custom/istio-rbac.yaml
+++ b/argo-cd/3-custom/istio-rbac.yaml
@@ -1,0 +1,26 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: argo-istio-rbac
+  namespace: istio-system
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: argo-istio
+  namespace: istio-system
+subjects:
+  - kind: ServiceAccount
+    name: argocd-application-controller
+    namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-istio-rbac

--- a/argo-cd/3-custom/kustomization.yaml
+++ b/argo-cd/3-custom/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - ../2-base
   - authorization.yaml
+  - istio-rbac.yaml
 
 patchesStrategicMerge:
   - argocd-application-controller.yaml

--- a/argo-cd/overlays-2/dev/argocd-cm.yaml
+++ b/argo-cd/overlays-2/dev/argocd-cm.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cm
+  namespace: argocd
 data:
   url: https://argocd-dev.test.mhra.gov.uk

--- a/argo-cd/overlays-2/dev/kustomization.yaml
+++ b/argo-cd/overlays-2/dev/kustomization.yaml
@@ -1,5 +1,3 @@
-namespace: argocd
-
 resources:
   - ../../3-custom
   - ../../applications/dev

--- a/argo-cd/overlays-2/local/argocd-cm.yaml
+++ b/argo-cd/overlays-2/local/argocd-cm.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cm
+  namespace: argocd
 data:
   url: https://argocd.localhost

--- a/argo-cd/overlays-2/local/kustomization.yaml
+++ b/argo-cd/overlays-2/local/kustomization.yaml
@@ -1,5 +1,3 @@
-namespace: argocd
-
 resources:
   - ../../3-custom
   - ../../applications/local

--- a/argo-cd/overlays-2/non-prod/argocd-cm.yaml
+++ b/argo-cd/overlays-2/non-prod/argocd-cm.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cm
+  namespace: argocd
 data:
   url: https://argocd.test.mhra.gov.uk

--- a/argo-cd/overlays-2/non-prod/kustomization.yaml
+++ b/argo-cd/overlays-2/non-prod/kustomization.yaml
@@ -1,5 +1,3 @@
-namespace: argocd
-
 resources:
   - ../../3-custom
   - ../../applications/non-prod

--- a/argo-cd/overlays-2/prod/argocd-cm.yaml
+++ b/argo-cd/overlays-2/prod/argocd-cm.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cm
+  namespace: argocd
 data:
   url: https://argocd-prod.test.mhra.gov.uk

--- a/argo-cd/overlays-2/prod/kustomization.yaml
+++ b/argo-cd/overlays-2/prod/kustomization.yaml
@@ -1,5 +1,3 @@
-namespace: argocd
-
 resources:
   - ../../3-custom
   - ../../applications/prod


### PR DESCRIPTION
Added rbac for ArgoCD to access istio-system after seeing errors in Argo relating to the `argocd-application-controller` not being able to access resources in the `istio-system` namespace. 

This likely follows changes made as a result of the penetration test to restrict argocd access outside of the `argocd` namespace, at which time role/rolebindings were added for the `doc-index-updater` and `medicines-api` namespaces.

Required removing the kustomize `namespace: argocd` override and applying at a resource level so that these resources could be created in the `istio-system` namespace. 

It makes sense for them to live here because these configurations are applied after the istio-system configs when initialising a cluster, and the service account for argocd should exist before creating the rolebindings.

![](https://media.giphy.com/media/T6V1Cy3CwEi88/giphy.gif)