### PR TITLE
Revert non-prod images for doc-index-updater and medicines-api

### DIFF
--- a/doc-index-updater/non-prod/manifests.yaml
+++ b/doc-index-updater/non-prod/manifests.yaml
@@ -210,7 +210,7 @@ spec:
             secretKeyRef:
               key: key
               name: logs-storage-creds
-        image: mhraproductsnonprodregistry.azurecr.io/products/doc-index-updater@sha256:66c7edf7dba8693ee6190222e2404a0d2af7f0ddf21569f83abb2e56321d2d31
+        image: mhraproductsnonprodregistry.azurecr.io/products/doc-index-updater@sha256:1e3487c5b0cdb48385af735908469b63ed645160396f6c4e2f101bac0eb57d0c
         livenessProbe:
           httpGet:
             path: /healthz

--- a/medicines-api/non-prod/manifests.yaml
+++ b/medicines-api/non-prod/manifests.yaml
@@ -107,7 +107,7 @@ spec:
           value: "4"
         - name: BMGF_AZURE_SEARCH_INDEX
           value: bmgf-index
-        image: mhraproductsnonprodregistry.azurecr.io/products/medicines-api@sha256:ec41b8172c399f51de6a751651676d74c1531146f2b0ad537416f762d1c72ad8
+        image: mhraproductsnonprodregistry.azurecr.io/products/medicines-api@sha256:527b606eda7fed77f5991675d16094a3a6bb33ca922a4d9bb2ddb45c44b91896
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Bug in workflows reverts image digest in manifests to previous version if there are no code updates to the apps themselves (only manifest changes). 

This is a temporary fix to revert the images back to their latest version - a PR in the Products repository will fix the workflow bugs.